### PR TITLE
Richcmp support

### DIFF
--- a/pyo3_special_method_derive/tests/richcmp.rs
+++ b/pyo3_special_method_derive/tests/richcmp.rs
@@ -1,0 +1,21 @@
+use pyo3::{basic::CompareOp, pyclass};
+use pyo3_special_method_derive::richcmp_derive_with;
+
+#[derive(PartialEq, PartialOrd)]
+#[pyclass]
+#[richcmp_derive_with(PartialEq, PartialOrd)]
+struct Point(f32, f32);
+
+#[test]
+fn eq() {
+    let a = Point(1., 1.);
+    let b = Point(1., 1.);
+    assert!(a.__richcmp__(&b, CompareOp::Eq).unwrap());
+}
+
+#[test]
+fn le() {
+    let a = Point(2., 2.);
+    let b = Point(1., 1.);
+    assert!(a.__richcmp__(&b, CompareOp::Gt).unwrap());
+}

--- a/pyo3_special_method_derive_macro/src/lib.rs
+++ b/pyo3_special_method_derive_macro/src/lib.rs
@@ -1068,7 +1068,7 @@ pub fn richcmp_derive_with(args: TokenStream, input: TokenStream) -> TokenStream
     };
 
     let expanded = quote! {
-        #input 
+        #input
 
         #[pyo3::pymethods]
         impl #name {


### PR DESCRIPTION
```rust
#[derive(PartialEq, PartialOrd)]
#[pyclass]
#[richcmp_derive_with(PartialEq, PartialOrd)]
struct Point(f32, f32);
```