### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af  # v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505  # v1
         with:
           command: check
 
@@ -38,13 +38,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af  # v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505  # v1
         env:
           TESTS_HF_TOKEN: ${{ secrets.HF_TOKEN }}
         with:
@@ -55,14 +55,14 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af  # v1
         with:
           profile: minimal
           toolchain: stable
           override: true
       - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505  # v1
         with:
           command: fmt
           args: --all -- --check
@@ -71,14 +71,14 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af  # v1
         with:
           profile: minimal
           toolchain: stable
           override: true
       - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505  # v1
         with:
           command: clippy
           args: --workspace --tests --examples -- -D warnings
@@ -87,13 +87,13 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af  # v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505  # v1
         with:
           command: doc
           args: --workspace
@@ -102,19 +102,19 @@ jobs:
     name: Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af  # v1
         with:
           profile: minimal
           toolchain: stable
           override: true
       - name: Typos check with custom config file
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d  # master
         with:
           config: .typos.toml
   
   # markdown-link-check:
   #   runs-on: ubuntu-latest
   #   steps:
-  #   - uses: actions/checkout@master
+  #   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
   #   - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `ci.yml` | `actions/checkout` | `v2` | `v6.0.2` | `de0fac2e4500…` |
| `ci.yml` | `actions-rs/toolchain` | `v1` | `v1` | `16499b5e05bf…` |
| `ci.yml` | `actions-rs/cargo` | `v1` | `v1` | `844f36862e91…` |
| `ci.yml` | `actions/checkout` | `v2` | `v6.0.2` | `de0fac2e4500…` |
| `ci.yml` | `actions-rs/toolchain` | `v1` | `v1` | `16499b5e05bf…` |
| `ci.yml` | `actions-rs/cargo` | `v1` | `v1` | `844f36862e91…` |
| `ci.yml` | `actions/checkout` | `v2` | `v6.0.2` | `de0fac2e4500…` |
| `ci.yml` | `actions-rs/toolchain` | `v1` | `v1` | `16499b5e05bf…` |
| `ci.yml` | `actions-rs/cargo` | `v1` | `v1` | `844f36862e91…` |
| `ci.yml` | `actions/checkout` | `v2` | `v6.0.2` | `de0fac2e4500…` |
| `ci.yml` | `actions-rs/toolchain` | `v1` | `v1` | `16499b5e05bf…` |
| `ci.yml` | `actions-rs/cargo` | `v1` | `v1` | `844f36862e91…` |
| `ci.yml` | `actions/checkout` | `v2` | `v6.0.2` | `de0fac2e4500…` |
| `ci.yml` | `actions-rs/toolchain` | `v1` | `v1` | `16499b5e05bf…` |
| `ci.yml` | `actions-rs/cargo` | `v1` | `v1` | `844f36862e91…` |
| `ci.yml` | `actions/checkout` | `v2` | `v6.0.2` | `de0fac2e4500…` |
| `ci.yml` | `actions-rs/toolchain` | `v1` | `v1` | `16499b5e05bf…` |
| `ci.yml` | `crate-ci/typos` | `master` | `master` | `02ea592e44b3…` |
| `ci.yml` | `actions/checkout` | `master` | `v6.0.2` | `de0fac2e4500…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#238